### PR TITLE
build: add DEPR issue automation

### DIFF
--- a/.github/workflows/add-depr-ticket-to-depr-board.yml
+++ b/.github/workflows/add-depr-ticket-to-depr-board.yml
@@ -1,0 +1,12 @@
+# Run the workflow that adds DEPR labeled issues
+# to the org-wide DEPR project board
+
+name: Add newly created DEPR issues to the DEPR project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  routeissue:
+    uses: openedx/.github/.github/workflows/add-depr-ticket-to-depr-board.yml@master


### PR DESCRIPTION
## Description

As per the [steps in OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html#document) there are now default templates for DEPR issues and a default config for all Issues that turns on DEPR issues, a Forums redirect, and an option for a blank ticket.

Since this repo has previously had Issues turned on, the new default behavior will be inherited. Only the automation will be put into this repo, since workflows don't directly inherit.

## Background

Please see the discussion in https://github.com/openedx/open-edx-proposals/pull/280 if you would like detail on "how" we are rolling out this change.

Also see [slack thread 1](https://openedx.slack.com/archives/C02M89BSV9A/p1642693537008400), [slack thread 2](https://openedx.slack.com/archives/C02M89BSV9A/p1644353782380809).
