### PR TITLE
feanil/fix codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && matrix.toxenv=='core'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,7 +3,7 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 tox-travis                # Match Travis jobs to tox environments
+coverage                  # Calculate code coverage of tests.

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,22 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
+coverage==7.2.3
     # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -44,7 +34,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 tox-travis==0.13
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,27 +4,15 @@
 #
 #    make upgrade
 #
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/needle.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/needle.txt
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
-    # via
-    #   -r requirements/ci.txt
-    #   requests
-charset-normalizer==3.1.0
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 click==8.1.3
     # via
     #   -r requirements/needle.txt
@@ -41,13 +29,10 @@ code-annotations==1.3.0
     # via
     #   -r requirements/needle.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/needle.txt
-    #   codecov
     #   pytest-cov
 dill==0.3.6
     # via
@@ -57,7 +42,7 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/needle.txt
 exceptiongroup==1.1.1
     # via
@@ -67,15 +52,11 @@ execnet==1.9.0
     # via
     #   -r requirements/needle.txt
     #   pytest-xdist
-filelock==3.9.0
+filelock==3.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-idna==3.4
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 iniconfig==2.0.0
     # via
     #   -r requirements/needle.txt
@@ -110,7 +91,7 @@ nose==1.3.7
     # via
     #   -r requirements/needle.txt
     #   needle
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/needle.txt
@@ -122,13 +103,13 @@ pbr==5.11.1
     # via
     #   -r requirements/needle.txt
     #   stevedore
-pillow==9.4.0
+pillow==9.5.0
     # via
     #   -r requirements/needle.txt
     #   needle
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/needle.txt
@@ -146,7 +127,7 @@ py==1.11.0
     #   tox
 pycodestyle==2.10.0
     # via -r requirements/needle.txt
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   -r requirements/needle.txt
     #   edx-lint
@@ -170,7 +151,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/needle.txt
     #   pytest-cov
@@ -187,10 +168,6 @@ pyyaml==6.0
     # via
     #   -r requirements/needle.txt
     #   code-annotations
-requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   codecov
 selenium==3.141.0
     # via
     #   -r requirements/needle.txt
@@ -220,7 +197,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/needle.txt
     #   pylint
@@ -241,15 +218,13 @@ typing-extensions==4.5.0
     #   pylint
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/needle.txt
-    #   requests
     #   selenium
 virtualenv==20.21.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -24,7 +24,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -32,13 +32,13 @@ lazy==1.5
     # via -r requirements/base.txt
 markupsafe==2.1.2
     # via jinja2
-packaging==23.0
+packaging==23.1
     # via sphinx
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   readme-renderer
     #   sphinx
-pytz==2022.7.1
+pytz==2023.3
     # via babel
 readme-renderer==37.3
     # via -r requirements/doc.in

--- a/requirements/needle.txt
+++ b/requirements/needle.txt
@@ -4,15 +4,11 @@
 #
 #    make upgrade
 #
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 click==8.1.3
     # via
     #   -r requirements/test.txt
@@ -27,7 +23,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -35,7 +31,7 @@ dill==0.3.6
     # via
     #   -r requirements/test.txt
     #   pylint
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/test.txt
 exceptiongroup==1.1.1
     # via
@@ -77,7 +73,7 @@ needle==0.5.0
     # via -r requirements/needle.in
 nose==1.3.7
     # via needle
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -85,9 +81,9 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pillow==9.4.0
+pillow==9.5.0
     # via needle
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -97,7 +93,7 @@ pluggy==1.0.0
     #   pytest
 pycodestyle==2.10.0
     # via -r requirements/test.txt
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -117,7 +113,7 @@ pylint-plugin-utils==0.7
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -156,7 +152,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,15 +8,15 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,12 +4,10 @@
 #
 #    make upgrade
 #
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via pytest
 click==8.1.3
     # via
     #   click-log
@@ -19,11 +17,11 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via pytest-cov
 dill==0.3.6
     # via pylint
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/test.in
 exceptiongroup==1.1.1
     # via pytest
@@ -45,19 +43,19 @@ mccabe==0.7.0
     # via pylint
 mock==5.0.1
     # via -r requirements/test.in
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.in
     #   pytest
 pbr==5.11.1
     # via stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via pytest
 pycodestyle==2.10.0
     # via -r requirements/test.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -71,7 +69,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-xdist
@@ -96,7 +94,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via


### PR DESCRIPTION
- build: Don't install codecov as a dependency.
- chore: Run make upgrade.
