### PR TITLE
build: update to 2.0.2 for final release before archival

### DIFF
--- a/bok_choy/__init__.py
+++ b/bok_choy/__init__.py
@@ -9,4 +9,4 @@ NOISY_LOGGERS = ['selenium.webdriver.remote.remote_connection', 'paramiko.transp
 for log_name in NOISY_LOGGERS:
     logging.getLogger(log_name).setLevel(logging.WARNING)
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 
 from setuptools import setup
 
-DESCRIPTION = 'UI-level acceptance test framework'
+DESCRIPTION = 'Deprecated UI-level acceptance test framework'
 
 
 def load_requirements(*requirements_paths):
@@ -114,7 +114,7 @@ setup(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     license='Apache 2.0',
-    classifiers=['Development Status :: 5 - Production/Stable',
+    classifiers=['Development Status :: 7 - Inactive',
                  'Environment :: Console',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Bok-Choy has been deprecated since Feb 2022
(https://github.com/openedx/public-engineering/issues/13). The docs were updated, but a new release was never pushed to PyPI, until now.

Also in this commit: Update "Development Status" metadata field in setup.py to "7 - Inactive".