### PR TITLE
docs: Update the security e-mail address.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ may be asked to sign a Contributor Agreement.
 Reporting Security Issues
 -------------------------
 
-Please do not report security issues in public. Please email security@edx.org
+Please do not report security issues in public. Please email security@openedx.org
 
 
 Mailing List and IRC Channel


### PR DESCRIPTION
This repository is now managed by the Axim Collaborative and security issues
with it should be reported to security@openedx.org instead of security@edx.org

This work is being done as a part of https://github.com/openedx/wg-security/issues/16
